### PR TITLE
Arreglando el tamanio de la imagen de descripcion de pokemon

### DIFF
--- a/pages/detallesPokemon.html
+++ b/pages/detallesPokemon.html
@@ -100,8 +100,8 @@
         <article class="m-5">
           <h1 class="text-center">Squirtle <span class="text-secondary">#0007</span></h1>
           <div class="mt-5 row">
-            <aside class="col-xl-6 ml">
-              <img class="img-fluid" src="../img/007.png" alt="imagen de un Squirtle sonriente">
+            <aside class="col-xl-6">
+              <img class="w-100" src="../img/007.png" alt="imagen de un Squirtle sonriente">
             </aside>
             <aside class="col-xl-6">
               <p>


### PR DESCRIPTION
La imagen aparecía demasiado pequeña y fuera del centro. Ahora esta arreglado.